### PR TITLE
Ga4gh variantcontexttovariant - need help

### DIFF
--- a/convert-ga4gh/pom.xml
+++ b/convert-ga4gh/pom.xml
@@ -58,5 +58,9 @@
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+    <groupId>org.bdgenomics.adam</groupId>
+    <artifactId>adam-core${spark.version.prefix}${scala.version.prefix}</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/convert-ga4gh/pom.xml
+++ b/convert-ga4gh/pom.xml
@@ -62,5 +62,11 @@
     <groupId>org.bdgenomics.adam</groupId>
     <artifactId>adam-core${spark.version.prefix}${scala.version.prefix}</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.bdgenomics.utils</groupId>
+      <artifactId>utils-misc_${scala.version.prefix}</artifactId>
+    </dependency>
+
   </dependencies>
 </project>

--- a/convert-ga4gh/src/main/java/org/bdgenomics/convert/ga4gh/VariantContextToVariant.java
+++ b/convert-ga4gh/src/main/java/org/bdgenomics/convert/ga4gh/VariantContextToVariant.java
@@ -1,0 +1,55 @@
+package org.bdgenomics.convert.ga4gh;
+
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.concurrent.Immutable;
+
+import ga4gh.Common.Position;
+import ga4gh.Common.Strand;
+
+import ga4gh.Reads.CigarUnit;
+import ga4gh.Reads.LinearAlignment;
+import ga4gh.Reads.ReadAlignment;
+
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.TextCigarCodec;
+
+import org.bdgenomics.convert.AbstractConverter;
+import org.bdgenomics.convert.Converter;
+import org.bdgenomics.convert.ConversionException;
+import org.bdgenomics.convert.ConversionStringency;
+
+import org.bdgenomics.formats.avro.AlignmentRecord;
+
+import org.slf4j.Logger;
+
+import org.bdgenomics.adam.models.VariantContext;
+import ga4gh.Variants;
+
+import ga4gh.Variants.Call;
+
+
+
+/**
+ * Created by paschalj on 9/16/17.
+ */
+
+@Immutable
+final class VariantContextToVariant extends AbstractConverter<org.bdgenomics.adam.models.VariantContext, ga4gh.Variants.Variant> {
+
+
+    VariantContextToVariant() {
+        super(org.bdgenomics.adam.models.VariantContext.class, ga4gh.Variants.Variant.class);
+    }
+
+    @Override
+    public ga4gh.Variants.Variant convert(final org.bdgenomics.adam.models.VariantContext variantContext,
+                                          final ConversionStringency stringency,
+                                          final Logger logger) throws ConversionException {
+        return ga4gh.Variants.Variant.newBuilder().build();
+        
+    }
+}

--- a/convert-ga4gh/src/main/java/org/bdgenomics/convert/ga4gh/VariantContextToVariant.java
+++ b/convert-ga4gh/src/main/java/org/bdgenomics/convert/ga4gh/VariantContextToVariant.java
@@ -3,10 +3,13 @@ package org.bdgenomics.convert.ga4gh;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.annotation.concurrent.Immutable;
 
+import com.google.protobuf.ListValue;
+import com.google.protobuf.Value;
 import ga4gh.Common.Position;
 import ga4gh.Common.Strand;
 
@@ -23,10 +26,15 @@ import org.bdgenomics.convert.ConversionException;
 import org.bdgenomics.convert.ConversionStringency;
 
 import org.bdgenomics.formats.avro.AlignmentRecord;
+import org.bdgenomics.formats.avro.Genotype;
 
+
+import org.bdgenomics.formats.avro.Genotype;
+import org.bdgenomics.formats.avro.GenotypeAllele;
 import org.slf4j.Logger;
 
 import org.bdgenomics.adam.models.VariantContext;
+
 import ga4gh.Variants;
 
 import ga4gh.Variants.Call;
@@ -45,11 +53,58 @@ final class VariantContextToVariant extends AbstractConverter<org.bdgenomics.ada
         super(org.bdgenomics.adam.models.VariantContext.class, ga4gh.Variants.Variant.class);
     }
 
+
+    String toGA4GHAllele(org.bdgenomics.formats.avro.GenotypeAllele genotypeAllele) {
+        if (genotypeAllele == GenotypeAllele.REF || genotypeAllele == GenotypeAllele.OTHER_ALT) return "0";
+        else if (genotypeAllele == GenotypeAllele.ALT ) return "1";
+        else return ".";
+
+    }
+
+    ga4gh.Variants.Call genotypeToCall(org.bdgenomics.formats.avro.Genotype genotype) {
+
+        java.util.List<GenotypeAllele> inputAlleles = genotype.getAlleles();
+        String alleleFirst = toGA4GHAllele(inputAlleles.get(0));
+        String alleleSecond = "";
+        if (inputAlleles.size() == 2) {
+            alleleSecond = toGA4GHAllele(inputAlleles.get(1));
+        }
+        else {
+            alleleSecond = ".";
+        }
+
+
+        com.google.protobuf.Value alleleFirstValue = com.google.protobuf.Value.newBuilder().setStringValue(alleleFirst).build();
+        com.google.protobuf.Value alleleSecondtValue = com.google.protobuf.Value.newBuilder().setStringValue(alleleSecond).build();
+
+        com.google.protobuf.ListValue calls = ListValue.newBuilder().addValues(alleleFirstValue).addValues(alleleSecondtValue).build();
+
+        java.util.List<Double> gl = genotype.getGenotypeLikelihoods();
+
+        ga4gh.Variants.Call.Builder builder = ga4gh.Variants.Call.newBuilder().setCallSetName(genotype.getSampleId())
+                                              .setCallSetId("NA").setGenotype(calls);
+
+        if (genotype.getPhased()) {
+            builder = builder.setPhaseset(genotype.getPhaseSetId().toString());
+
+        }
+        if (!gl.isEmpty()) {
+            builder = builder.addAllGenotypeLikelihood(gl);
+        }
+
+
+
+
+        return ga4gh.Variants.Call.newBuilder().build();
+    }
+
     @Override
     public ga4gh.Variants.Variant convert(final org.bdgenomics.adam.models.VariantContext variantContext,
                                           final ConversionStringency stringency,
                                           final Logger logger) throws ConversionException {
+
+
         return ga4gh.Variants.Variant.newBuilder().build();
-        
+
     }
 }

--- a/convert-ga4gh/src/test/java/org/bdgenomics/convert/ga4gh/VariantContextToVariantTest.java
+++ b/convert-ga4gh/src/test/java/org/bdgenomics/convert/ga4gh/VariantContextToVariantTest.java
@@ -1,0 +1,113 @@
+package org.bdgenomics.convert.ga4gh;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.google.protobuf.util.JsonFormat;
+
+import ga4gh.Common.Strand;
+
+import ga4gh.Reads.CigarUnit;
+import ga4gh.Reads.CigarUnit.Operation;
+
+import ga4gh.Reads.ReadAlignment;
+
+import ga4gh.ReadServiceOuterClass.SearchReadsResponse;
+
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.CigarOperator;
+
+import org.bdgenomics.convert.ConversionException;
+import org.bdgenomics.convert.ConversionStringency;
+import org.bdgenomics.convert.Converter;
+
+import org.bdgenomics.formats.avro.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import ga4gh.Variants;
+import ga4gh.Variants.Call;
+import org.bdgenomics.adam.models.VariantContext;
+
+import org.bdgenomics.adam.models.VariantContext;
+import org.bdgenomics.adam.models.SequenceDictionary;
+import org.bdgenomics.adam.models.SequenceRecord;
+
+import org.bdgenomics.formats.avro.AlignmentRecord;
+import org.bdgenomics.formats.avro.Variant;
+import org.bdgenomics.formats.avro.Genotype;
+
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import scala.Predef;
+import scala.collection.Seq;
+import scala.collection.JavaConverters;
+
+/**
+ * Created by paschalj on 9/16/17.
+ */
+public final class VariantContextToVariantTest {
+    private final Logger logger = LoggerFactory.getLogger(VariantContextToVariantTest.class);
+    private Converter<org.bdgenomics.adam.models.VariantContext, ga4gh.Variants.Variant> variantContextConverter;
+    private org.bdgenomics.adam.models.VariantContext variantContext;
+
+
+
+    @Before
+    public void setUp() {
+        variantContextConverter = new VariantContextToVariant();
+
+        org.bdgenomics.formats.avro.Variant v0 = Variant.newBuilder()
+                .setContigName("chr11")
+                .setStart(17409572L)
+                .setEnd(17409573L)
+                .setReferenceAllele("T")
+                .setAlternateAllele("C")
+                .setNames(Arrays.asList("rs3131972", "rs201888535"))
+                .setFiltersApplied(true)
+                .setFiltersPassed(true)
+                .build();
+
+              org.bdgenomics.formats.avro.Genotype g0 = Genotype.newBuilder().setVariant(v0)
+                .setSampleId("NA12878")
+                .setAlleles(Arrays.asList(GenotypeAllele.REF, GenotypeAllele.ALT))
+                .build();
+
+
+        List<Genotype> g1 = new ArrayList<>();
+        g1.add(g0);
+
+        Seq<Genotype> g1_scala = JavaConverters.asScalaBufferConverter(g1).asScala().toSeq();
+
+
+        org.bdgenomics.adam.models.VariantContext variantContext = org.bdgenomics.adam.models.VariantContext.buildFromGenotypes(g1_scala);
+
+
+    }
+
+
+    @Test
+    public void testConvert() {
+
+        ga4gh.Variants.Variant variant = variantContextConverter.convert(variantContext, ConversionStringency.STRICT, logger);
+
+
+    }
+/*
+    @Test
+    public void testConstructor() {
+        assertNotNull(variantContextConverter);
+    }
+
+*/
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
   <properties>
     <java.version>1.8</java.version>
     <bdg-formats.version>0.11.1</bdg-formats.version>
+    <bdg-utils.version>0.2.13</bdg-utils.version>
     <commons-lang3.version>3.6</commons-lang3.version>
     <ga4gh.version>0.6.0a10</ga4gh.version>
     <guice.version>4.1.0</guice.version>
@@ -220,6 +221,15 @@
           </exclusion>
         </exclusions>
       </dependency>
+
+      <dependency>
+      <groupId>org.bdgenomics.utils</groupId>
+      <artifactId>utils-misc_${scala.version.prefix}</artifactId>
+      <version>${bdg-utils.version}</version>
+      </dependency>
+
+
+
     </dependencies>
   </dependencyManagement>
 
@@ -230,7 +240,8 @@
   </modules>
 
   <profiles>
-    <!-- Only sign artifacts when we are performing a release, not snapshots -->
+   <!--
+
     <profile>
       <id>sonatype-oss-release</id>
       <build>
@@ -252,5 +263,8 @@
         </plugins>
       </build>
     </profile>
+    -->
+
+
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,10 @@
     <junit.version>4.12</junit.version>
     <protobuf.version>3.0.0-beta-3</protobuf.version>
     <slf4j.version>1.7.22</slf4j.version>
+    <scala.version>2.10.6</scala.version>
+    <scala.version.prefix>2.10</scala.version.prefix>
+    <adam.version>0.21.1-SNAPSHOT</adam.version>
+    <spark.version.prefix>_</spark.version.prefix>
   </properties>
 
   <licenses>
@@ -204,6 +208,17 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-simple</artifactId>
         <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bdgenomics.adam</groupId>
+        <artifactId>adam-core${spark.version.prefix}${scala.version.prefix}</artifactId>
+        <version>${adam.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.bdgenomics.utils</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
in progress PR to convert `org.bdgenomics.adam.models.VariantContext` to ` ga4gh.Variants.Variant`

need help to resolve an error during compile:
```
java.lang.NoClassDefFoundError: org/bdgenomics/utils/interval/array/Interval
	at org.bdgenomics.convert.ga4gh.VariantContextToVariantTest.setUp(VariantContextToVariantTest.java:92)
Caused by: java.lang.ClassNotFoundException: org.bdgenomics.utils.interval.array.Interval
```
error is reported at line 92 of VariantContextToVariantTest.java
Not sure why this bdgenomics utils class cannot be found.

note:  unrelated to above error, I realize that I can split out the `genotypeToCall` and `toGA4GHAllele` converts into further individual converters that can be nested.  Will do so once above is working and basic conversion works.

@heuermh  or @almussel  any ideas?
